### PR TITLE
Adds string representation for custom fields

### DIFF
--- a/src/Command/CustomFieldUpdateCommand.php
+++ b/src/Command/CustomFieldUpdateCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace CubeTools\CubeCustomFieldsBundle\Command;
+
+use Symfony\Bundle\FrameworkBundle\Command\ContainerAwareCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Refreshes the leaves of all accessRights based on the current accessGroup configuration
+ *
+ */
+class CustomFieldUpdateCommand extends ContainerAwareCommand
+{
+    private $output; // OutputInterface
+
+    protected function configure()
+    {
+        $this
+            ->setName('cube:customfield:update')
+            ->setDescription('Updates the string representation of the custom fields table entries.')
+        ;
+    }
+
+    /**
+     * Cleans up access rights
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @return boolean
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $em = $this->getContainer()->get('doctrine.orm.entity_manager');
+        // entity custom fields
+        $entityCf = $em->getRepository('CubeCustomFieldsBundle:EntityCustomField')->findAll();
+        $this->updateCfEntities($entityCf);
+
+        // datetime custom fields
+        $datetimeCf = $em->getRepository('CubeCustomFieldsBundle:DatetimeCustomField')->findAll();
+        $this->updateCfEntities($datetimeCf);
+
+        // text custom fields
+        $textCf = $em->getRepository('CubeCustomFieldsBundle:TextCustomField')->findAll();
+        $this->updateCfEntities($textCf);
+
+        // textarea custom fields
+        $textareaCf = $em->getRepository('CubeCustomFieldsBundle:TextareaCustomField')->findAll();
+        $this->updateCfEntities($textareaCf);
+        $em->flush();
+    }
+
+    private function updateCfEntities($entities)
+    {
+        foreach ($entities as $entity) {
+            $entity->storeStrRepresentation();
+        }
+    }
+}

--- a/src/Entity/CustomFieldBase.php
+++ b/src/Entity/CustomFieldBase.php
@@ -17,6 +17,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 abstract class CustomFieldBase
 {
     protected $config;
+    protected $strRepresentationOnFlushCreated;
 
     public function __construct()
     {

--- a/src/Entity/CustomFieldBase.php
+++ b/src/Entity/CustomFieldBase.php
@@ -12,6 +12,7 @@ use Symfony\Component\Validator\Constraints as Assert;
  * @ORM\Table(name="custom_fields")
  * @ORM\InheritanceType("SINGLE_TABLE")
  * @ORM\DiscriminatorColumn("discr_type", type="string")
+ * @ORM\HasLifecycleCallbacks()
  */
 abstract class CustomFieldBase
 {
@@ -33,13 +34,20 @@ abstract class CustomFieldBase
      */
     private $id;
 
-        /**
+    /**
      * @var string
      *
      * @ORM\Column(type="string", nullable=false)
      * @Assert\NotBlank()
      */
     private $fieldId;
+
+    /**
+     * @var text
+     *
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $strRepresentation;
 
     /**
      * Get id
@@ -74,6 +82,40 @@ abstract class CustomFieldBase
     public function getFieldId()
     {
         return $this->fieldId;
+    }
+
+    /**
+     * Set the string representation of the custom field automatically during persisting
+     *
+     * @param string $str
+     *
+     * @return $this
+     *
+     */
+    public function setStrRepresentation($str)
+    {
+        $this->strRepresentation = $str;
+
+        return $this;
+    }
+
+    /**
+     * @ORM\PrePersist
+     * @ORM\PreUpdate
+     */
+    public function storeStrRepresentation()
+    {
+        $this->setStrRepresentation($this->createStrRepresentation());
+    }
+
+    /**
+     * Creates the string representation of the custom field. Should be overriden if required by the extending class.
+     *
+     * @return str
+     */
+    public function createStrRepresentation()
+    {
+        return $this->__toString();
     }
 
     /**

--- a/src/Entity/CustomFieldBase.php
+++ b/src/Entity/CustomFieldBase.php
@@ -23,6 +23,7 @@ abstract class CustomFieldBase
         // TODO: find a better way to retrieve the parameters from custom_fields.yml
         global $kernel;
         $this->config = $kernel->getContainer()->getParameter('cubetools.customfields.entities');
+        $this->strRepresentationOnFlushCreated = false;
     }
 
     /**
@@ -105,7 +106,16 @@ abstract class CustomFieldBase
      */
     public function storeStrRepresentation()
     {
-        $this->setStrRepresentation($this->createStrRepresentation());
+        if (!$this->strRepresentationOnFlushCreated) {
+            // we only want to store the string representation during update if it has not yet been done as part of the flush cycle of a related entity (refer to the EventListener)
+            $this->setStrRepresentation($this->createStrRepresentation());
+        }
+    }
+
+    public function storeStrRepresentationOnFlush($flushEntity)
+    {
+        $this->strRepresentationOnFlushCreated = true;
+        $this->setStrRepresentation($this->createStrRepresentationOnFlush($flushEntity));
     }
 
     /**
@@ -114,6 +124,16 @@ abstract class CustomFieldBase
      * @return str
      */
     public function createStrRepresentation()
+    {
+        return $this->__toString();
+    }
+
+    /**
+     * Creates the string representation of the custom field during flush of a possibly related entity. Should be overriden if required by the extending class.
+     *
+     * @return str
+     */
+    public function createStrRepresentationOnFlush($flushEntity)
     {
         return $this->__toString();
     }

--- a/src/Entity/EntityCustomField.php
+++ b/src/Entity/EntityCustomField.php
@@ -85,6 +85,42 @@ class EntityCustomField extends CustomFieldBase
     }
 
     /**
+     * Override the default string representation creator method for the onFlush event
+     *
+     * @return string
+     */
+    public function createStrRepresentationOnFlush($flushEntity)
+    {
+        $entity = $this->getEntityData();
+        if (is_array($entity) || $entity instanceof \ArrayAccess) {
+            $entityArr = array();
+            foreach ($entity as $elem) {
+                $entityArr[] = $this->getEntityOnFlush($elem, $flushEntity);
+            }
+            return implode("\x1E", $entityArr); // ASCII "record separator" character
+        } elseif ($entity) {
+            return $this->getEntityOnFlush($entity, $flushEntity)->__toString();
+        } else {
+            return '';
+        }
+    }
+
+    /**
+     * Checks if the two passed objects are "the same" but possibly in different states. Returns the second argument if they are the same, else the first
+     * @param type $entity
+     * @param type $flushEntity
+     * @return type
+     */
+    private function getEntityOnFlush($entity, $flushEntity)
+    {
+        if (get_class($entity) == get_class($flushEntity) && $entity->getId() === $flushEntity->getId()) {
+            return $flushEntity;
+        } else {
+            return $entity;
+        }
+    }
+
+    /**
      * Returns true when the entity (its value) is empty.
      *
      * @return boolean

--- a/src/Entity/EntityCustomField.php
+++ b/src/Entity/EntityCustomField.php
@@ -68,6 +68,23 @@ class EntityCustomField extends CustomFieldBase
     }
 
     /**
+     * Override the default string representation creator method
+     *
+     * @return string
+     */
+    public function createStrRepresentation()
+    {
+        $entity = $this->getEntityData();
+        if (is_array($entity) || $entity instanceof \ArrayAccess) {
+            return implode("\x1E", $entity); // ASCII "record separator" character
+        } elseif ($entity) {
+            return $entity->__toString();
+        } else {
+            return '';
+        }
+    }
+
+    /**
      * Returns true when the entity (its value) is empty.
      *
      * @return boolean

--- a/src/EventListener/CustomFieldLinkedEntityListener.php
+++ b/src/EventListener/CustomFieldLinkedEntityListener.php
@@ -1,0 +1,40 @@
+<?php
+namespace CubeTools\CubeCustomFieldsBundle\EventListener;
+
+use CubeTools\CubeCustomFieldsBundle\Utils\ConfigReader;
+use CubeTools\CubeCustomFieldsBundle\Utils\CustomFieldRepoService;
+use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\Common\Persistence\ObjectManager;
+
+class CustomFieldLinkedEntityListener
+{
+    public function __construct(ConfigReader $config, CustomFieldRepoService $cfRepo)
+    {
+        $this->config = $config;
+        $this->cfRepo = $cfRepo;
+    }
+
+    public function onFlush(OnFlushEventArgs $args)
+    {
+        $em = $args->getEntityManager();
+        $uow = $em->getUnitOfWork();
+
+        // we are interested in updated entities which may be referenced through EntityCustomFields
+        foreach ($uow->getScheduledEntityUpdates() as $entity) {
+            // iterate over all entity types referenced in custom fields config
+            foreach ($this->config->getLinkedEntities() as $linkedEntity) {
+                if ($entity instanceof $linkedEntity['class']) {
+                    // get all custom fields which reference the $entity
+                    $affectedCustomFields = $this->cfRepo->getCustomFieldEntitiesForObject($linkedEntity['fieldId'], $entity);
+                    // update the affected custom fields string representation and recompute the change-set instead of flushing, since we are already in flush process
+                    foreach ($affectedCustomFields as $cf) {
+                        $cf->storeStrRepresentationOnFlush($entity);
+                        $em->persist($cf);
+                        $cfMetadata = $em->getClassMetadata(get_class($cf));
+                        $uow->computeChangeSet($cfMetadata, $cf);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -26,3 +26,8 @@ services:
         autoconfigure: true
         arguments:
             $config: '%cubetools.customfields.entities%'
+    CubeTools\CubeCustomFieldsBundle\EventListener\CustomFieldLinkedEntityListener:
+        autowire: true
+        autoconfigure: true
+        tags:
+            - { name: doctrine.event_listener, event: onFlush }

--- a/src/Utils/ConfigReader.php
+++ b/src/Utils/ConfigReader.php
@@ -2,6 +2,8 @@
 
 namespace CubeTools\CubeCustomFieldsBundle\Utils;
 
+use CubeTools\CubeCustomFieldsBundle\EntityHelper\EntityMapper;
+
 /**
  * This service class allows access to the bundle configuration (custom_fields.yml)
  */
@@ -32,5 +34,25 @@ class ConfigReader
         }
 
         return array();
+    }
+
+    /**
+     * returns an array of class names (indexed by the respective fieldId) which are linked with custom fields
+     */
+    public function getLinkedEntities()
+    {
+        $linkedClasses = array();
+        foreach ($this->config as $entityConfig) {
+            foreach ($entityConfig as $fieldId => $field) {
+                if (isset($field['type']) && EntityMapper::isEntityField($field['type'] && isset($field['field_options']) && isset($field['field_options']['class']))) {
+                    $linkedClasses[] = array(
+                        'fieldId' => $fieldId,
+                        'class' => $field['field_options']['class'],
+                    );
+                }
+            }
+        }
+
+        return $linkedClasses;
     }
 }


### PR DESCRIPTION
Allows for performance improved fulltext filtering over custom fields
To be tested with branch 1245_fulltextsearch of CUBE PA.

In order to initialize the string representation of existing custom fields, run:
<code>bin/console cube:customfield:update</code>

To be tested explicitely:
- [x] fulltext filtering after executing the above command
- [x] change the name / title etc. of an associated entity which is linked through customfields (either an entity which is itself a custom field or is a static entity). After the change, filtering for the new name / title must work again.
- [x] try with many-to-one and many-to-many custom fields

If tests are successfull, this PR can be merged via development into master, and a new release can be created.
CUBE PA pull request https://github.com/EmchBerger/projectassistant/pull/1386 to be amended with updated composer.lock file (including the new custom fields bundle version) and to be merged.