### PR TITLE
switched to FOS CKEditor bundle. BC break!

### DIFF
--- a/src/EntityHelper/EntityMapper.php
+++ b/src/EntityHelper/EntityMapper.php
@@ -9,7 +9,7 @@ class EntityMapper
 {
     private static $map = array(
         'Symfony\Component\Form\Extension\Core\Type\TextType' => 'CubeTools\CubeCustomFieldsBundle\Entity\TextCustomField',
-        'Ivory\CKEditorBundle\Form\Type\CKEditorType' => 'CubeTools\CubeCustomFieldsBundle\Entity\TextareaCustomField',
+        'FOS\CKEditorBundle\Form\Type\CKEditorType' => 'CubeTools\CubeCustomFieldsBundle\Entity\TextareaCustomField',
         'Symfony\Component\Form\Extension\Core\Type\TextareaType' => 'CubeTools\CubeCustomFieldsBundle\Entity\TextareaCustomField', // we have two mapping for TextareaCustomField. the second (default textarea) is used only in "getCustomFieldClass"
         'Symfony\Component\Form\Extension\Core\Type\DateTimeType' => 'CubeTools\CubeCustomFieldsBundle\Entity\DatetimeCustomField',
         'Tetranz\Select2EntityBundle\Form\Type\Select2EntityType' => 'CubeTools\CubeCustomFieldsBundle\Entity\EntityCustomField',

--- a/src/Utils/CustomFieldIndexService.php
+++ b/src/Utils/CustomFieldIndexService.php
@@ -39,7 +39,7 @@ class CustomFieldIndexService
                 // we can access the customField directly by its name (using the magic getter function in the custom field trait):
                 $value = $entity->$fieldGetter;
                 $raw = false;
-                if (array_key_exists($fieldGetter, $fieldConfig) && $fieldConfig[$fieldGetter]['type'] == 'Ivory\CKEditorBundle\Form\Type\CKEditorType') {
+                if (array_key_exists($fieldGetter, $fieldConfig) && $fieldConfig[$fieldGetter]['type'] == 'FOS\CKEditorBundle\Form\Type\CKEditorType') {
                     $raw = true;
                 }
                 if (is_object($value) && $value instanceof \DateTimeInterface) {

--- a/src/Utils/CustomFieldShowService.php
+++ b/src/Utils/CustomFieldShowService.php
@@ -60,7 +60,7 @@ class CustomFieldShowService
         } else {
             $showCfg['value'] = array($value);
         }
-        $showCfg['raw'] = ($fieldConfig['type'] == "Ivory\CKEditorBundle\Form\Type\CKEditorType");
+        $showCfg['raw'] = ($fieldConfig['type'] == "FOS\CKEditorBundle\Form\Type\CKEditorType");
 
         return $showCfg;
     }


### PR DESCRIPTION
Note: when using this version of the cube-custom-fields-bundle, make sure you are using the new FOS CKEditor bundle instead of the Ivory CKEditor bundle