### PR TITLE
Throw LogicException for unsupported types

### DIFF
--- a/src/EntityHelper/EntityMapper.php
+++ b/src/EntityHelper/EntityMapper.php
@@ -21,19 +21,18 @@ class EntityMapper
         if (array_key_exists($formClass, self::$map)) {
             return self::$map[$formClass];
         } else {
-            return null;
+            throw new \LogicException(sprintf('FormClass %s is not supported', $formClass));
         }
     }
 
     public static function getFormClass($customFieldClass)
     {
-        foreach (self::$map as $key => $elem) {
-            if ($elem == $customFieldClass) {
-                return $key;
-            }
+        $key = array_search($customFieldClass, self::$map, true);
+        if (false !== $key) {
+            return $key;
+        } else {
+            throw new \LogicException(sprintf('CustomFieldClass %s is not supported.', $customFieldClass));
         }
-
-        return null;
     }
 
     public static function isEntityField($formClass)

--- a/tests/EntityHelper/EntityMapperTest.php
+++ b/tests/EntityHelper/EntityMapperTest.php
@@ -17,12 +17,8 @@ class EntityMapperTest extends TestCase
         $cfTa = EntityMapper::getCustomFieldClass($ftTa);
         $this->assertSame('CubeTools\CubeCustomFieldsBundle\Entity\TextareaCustomField', $cfTa, $ftTa);
 
-        try { // currently accept two variants
-            $invalid = EntityMapper::getCustomFieldClass('not known form class');
-            $this->assertSame(null, $invalid);
-        } catch (\LogicException $e) {
-            $this->assertTrue(true);
-        }
+        $this->expectException(\LogicException::class);
+        EntityMapper::getCustomFieldClass('not known form class');
     }
 
     public function testGetFormClass()
@@ -31,12 +27,8 @@ class EntityMapperTest extends TestCase
         $ftTa = EntityMapper::getFormClass($cfTa);
         $this->assertSame('FOS\CKEditorBundle\Form\Type\CKEditorType', $ftTa, $cfTa);
 
-        try { // currently accept two variants
-            $invalid = EntityMapper::getFormClass('not known custom field class');
-            $this->assertSame(null, $invalid);
-        } catch (\LogicException $e) {
-            $this->assertTrue(true);
-        }
+        $this->expectException(\LogicException::class);
+        EntityMapper::getFormClass('not known custom field class');
     }
 
     public function testIsEntityField()


### PR DESCRIPTION
Do not return null as learnt from krisztof on a meeting.

Returning null results in exceptions telling something about null or objects. The new behaviour is more helpful.